### PR TITLE
Fix trade for 1.21 servers

### DIFF
--- a/docs/commands/trade.md
+++ b/docs/commands/trade.md
@@ -3,18 +3,19 @@ command:
   added: Pre-0.2.7
   aliases: []
   configuration: []
-  description: Opens a mutual chest between two players.
+  description: Opens a mutual inventory between two players
   permissions:
   - rcmds.trade
   supports:
-    name-completion: false
+    name-completion: true
     time-format: false
   usage: /trade [player]
 layout: command
 title: /trade
 ---
 
-In-depth content, and...
+```/trade``` opens the trade inventory window with ```(player)```
 
 ### Examples
 
+```/trade Notch``` - Opens the trade inventory window with ```Notch```.

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/gui/inventory/InventoryGUI.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/gui/inventory/InventoryGUI.java
@@ -62,7 +62,7 @@ public class InventoryGUI {
     }
 
     /**
-     * Tags an ItemStack with the given UUID, which can be used to quickly get the item again.
+     * Tags an ItemStack with the given Key, which can be used to quickly get the item again.
      *
      * @param is   ItemStack to tag
      * @param key Key to tag the item with
@@ -94,7 +94,7 @@ public class InventoryGUI {
 
     /**
      * Adds an item to the GUI. The given {@link ClickHandler} will be associated with this item. The item will be
-     * tagged with the given UUID.
+     * tagged with the given Key.
      *
      * @param key         Key to tag the item with
      * @param clickHandler ClickHandler to use for the item
@@ -158,10 +158,10 @@ public class InventoryGUI {
     }
 
     /**
-     * Gets an ItemStack from this GUI by its UUID tag.
+     * Gets an ItemStack from this GUI by its Key tag.
      *
      * @param key Key tag of item
-     * @return ItemStack or null if no matching UUID
+     * @return ItemStack or null if no matching Key
      */
     public ItemStack getItemStack(final NamespacedKey key) {
         if (key == null) return null;
@@ -229,7 +229,7 @@ public class InventoryGUI {
      * @param replacement Replacement ItemStack
      */
     public void replaceItemStack(final NamespacedKey key, final ItemStack replacement) {
-        if (key == null) throw new IllegalArgumentException("UUID cannot be null");
+        if (key == null) throw new IllegalArgumentException("Key cannot be null");
         for (int i = 0; i < this.getBase().getSize(); i++) {
             final ItemStack is = this.getBase().getItem(i);
             if (!key.equals(this.getTag(is))) continue;
@@ -255,14 +255,14 @@ public class InventoryGUI {
     }
 
     /**
-     * Sets the name of the ItemStack tagged with the given UUID.
+     * Sets the name of the ItemStack tagged with the given Key.
      *
      * @param key Key of the ItemStack
      * @param name New name
      */
     public void setName(final NamespacedKey key, final String name) {
         final ItemStack is = this.getItemStack(key);
-        if (is == null) throw new IllegalArgumentException("No such ItemStack UUID found");
+        if (is == null) throw new IllegalArgumentException("No such ItemStack Key found");
         this.replaceItemStack(key, this.setItemMeta(is, name));
     }
 

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/trade/Trade.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/trade/Trade.java
@@ -6,6 +6,7 @@
 package org.royaldev.royalcommands.rcommands.trade;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -50,10 +51,11 @@ import java.util.UUID;
 public class Trade {
 
     private static final Map<Pair<UUID, UUID>, Trade> trades = new HashMap<>();
+    private static final String TAG_NAME = "ig-tag";
     private final Map<Party, UUID> parties = new HashMap<>();
     private final Map<Party, Boolean> acceptances = new HashMap<>();
     private final InventoryGUI inventoryGUI;
-    private final UUID acceptButtonUUID = UUID.randomUUID();
+    private final NamespacedKey acceptButtonUUID = new NamespacedKey(Trade.TAG_NAME, String.valueOf(this.acceptButtonUUID));
 
     public Trade(final UUID trader, final UUID tradee) {
         this.parties.put(Party.TRADER, trader);


### PR DESCRIPTION
 /trade will now use NamespacedKeys for [AttributeModifiers ](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/attribute/AttributeModifier.html) than rather UUIDs. 
This makes future builds not supported for servers on <1.21 that want to use the /trade command

Slight improvement the help page for /trade 