### PR TITLE
Rework item aliases

### DIFF
--- a/modules/RoyalCommands/pom.xml
+++ b/modules/RoyalCommands/pom.xml
@@ -23,7 +23,7 @@
                 <includes>
                     <include>*.yml</include>
                     <include>*.txt</include>
-                    <include>items.csv</include>
+                    <include>item_aliases.csv</include>
                 </includes>
             </resource>
         </resources>

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/Config.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/Config.java
@@ -366,15 +366,15 @@ public class Config {
 
         Reader in = null;
         try {
-            in = new FileReader(new File(this.plugin.getDataFolder() + File.separator + "items.csv"));
+            in = new FileReader(new File(this.plugin.getDataFolder() + File.separator + "item_aliases.csv"));
             CSVReader reader = new CSVReader(in);
             RoyalCommands.inm = new ItemNameManager(reader.readAll());
             reader.close();
         } catch (FileNotFoundException e) {
-            this.plugin.getLogger().warning("items.csv was not found! Item aliases will not be used.");
+            this.plugin.getLogger().warning("item_aliases.csv was not found! Item aliases will not be used.");
             RoyalCommands.inm = null;
         } catch (final IOException e) {
-            this.plugin.getLogger().warning("Internal input/output error loading items.csv. Item aliases will not be used.");
+            this.plugin.getLogger().warning("Internal input/output error loading item_aliases.csv. Item aliases will not be used.");
             RoyalCommands.inm = null;
         } finally {
             try {

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/ItemNameManager.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/ItemNameManager.java
@@ -26,9 +26,10 @@ public class ItemNameManager {
     public ItemNameManager(Iterable<String[]> values) {
         for (String[] s : values) {
             if (s.length < 1) continue;
+            if (s[0].startsWith("#")) continue;
             String[] aliases;
             try {
-                aliases = s[2].split(",");
+                aliases = s[1].split(",");
             } catch (IndexOutOfBoundsException e) {
                 Logger l = Logger.getLogger("Minecraft");
                 l.warning("[RoyalCommands] Values passed in ItemNameManager invalid: ");
@@ -36,19 +37,19 @@ public class ItemNameManager {
                 continue;
             }
             Material m;
-            short data;
+            short data = 0;
             try {
                 m = Material.valueOf(s[0]);
             } catch (IllegalArgumentException ex) {
-                RoyalCommands.getInstance().getLogger().warning("Material in items.csv is invalid: " + s[0]);
+                RoyalCommands.getInstance().getLogger().warning("Material in item_aliases.csv is invalid: " + s[0]);
                 continue;
             }
-            try {
-                data = Short.valueOf(s[1]);
-            } catch (NumberFormatException e) {
-                RoyalCommands.getInstance().getLogger().warning("Data in items.csv file is invalid: " + s[1]);
-                continue;
-            }
+//            try {
+//                data = Short.valueOf(s[1]);
+//            } catch (NumberFormatException e) {
+//                RoyalCommands.getInstance().getLogger().warning("Data in item_aliases.csv file is invalid: " + s[1]);
+//                continue;
+//            }
             synchronized (items) {
                 items.put(aliases, new Pair<>(m, data));
             }

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/ItemNameManager.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/ItemNameManager.java
@@ -44,12 +44,6 @@ public class ItemNameManager {
                 RoyalCommands.getInstance().getLogger().warning("Material in item_aliases.csv is invalid: " + s[0]);
                 continue;
             }
-//            try {
-//                data = Short.valueOf(s[1]);
-//            } catch (NumberFormatException e) {
-//                RoyalCommands.getInstance().getLogger().warning("Data in item_aliases.csv file is invalid: " + s[1]);
-//                continue;
-//            }
             synchronized (items) {
                 items.put(aliases, new Pair<>(m, data));
             }

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/RUtils.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/RUtils.java
@@ -5,6 +5,7 @@
  */
 package org.royaldev.royalcommands;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.mvplugins.multiverse.core.world.LoadedMultiverseWorld;
 import org.mvplugins.multiverse.core.world.MultiverseWorld;
 
@@ -86,6 +87,7 @@ import org.royaldev.royalcommands.listeners.BackpackListener;
 import org.royaldev.royalcommands.rcommands.CmdBack;
 import org.royaldev.royalcommands.spawninfo.SpawnInfo;
 import org.royaldev.royalcommands.tools.NameFetcher;
+import org.royaldev.royalcommands.tools.Pair;
 import org.royaldev.royalcommands.tools.UUIDFetcher;
 
 @SuppressWarnings("unused")

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/RoyalCommands.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/RoyalCommands.java
@@ -392,7 +392,7 @@ public class RoyalCommands extends JavaPlugin {
 
     public void loadConfiguration() {
         if (!new File(getDataFolder(), "config.yml").exists()) saveDefaultConfig();
-        if (!new File(getDataFolder(), "items.csv").exists()) saveResource("items.csv", false);
+        if (!new File(getDataFolder(), "item_aliases.csv").exists()) saveResource("item_aliases.csv", false);
         if (!new File(getDataFolder(), "rules.txt").exists()) saveResource("rules.txt", false);
         if (!new File(getDataFolder(), "help.txt").exists()) saveResource("help.txt", false);
         if (!new File(getDataFolder(), "warps.yml").exists()) saveResource("warps.yml", false);

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdGive.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdGive.java
@@ -25,7 +25,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 public class CmdGive extends TabCommand {
 
     public CmdGive(final RoyalCommands instance, final String name) {
-        super(instance, name, true, new Short[]{CompletionType.ONLINE_PLAYER.getShort(), CompletionType.ITEM_ALIAS.getShort()});
+        super(instance, name, true, new Short[]{CompletionType.ONLINE_PLAYER.getShort(), CompletionType.ITEM.getShort()});
     }
 
     public static boolean giveItemStandalone(CommandSender cs, Player target, String itemname, int amount) {

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdHelmet.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdHelmet.java
@@ -21,7 +21,7 @@ import org.royaldev.royalcommands.exceptions.InvalidItemNameException;
 public class CmdHelmet extends TabCommand {
 
     public CmdHelmet(final RoyalCommands instance, final String name) {
-        super(instance, name, true, new Short[]{CompletionType.ITEM_ALIAS.getShort()});
+        super(instance, name, true, new Short[]{CompletionType.ITEM.getShort()});
     }
     /**
      * TODO: Add support to add a helmet to another player

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdItem.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdItem.java
@@ -30,7 +30,7 @@ public class CmdItem extends TabCommand {
     private static final Flag<String> loreFlag = new Flag<>(String.class, "description", "lore", "l");
 
     public CmdItem(final RoyalCommands instance, final String name) {
-        super(instance, name, true, new Short[]{CompletionType.ITEM_ALIAS.getShort()});
+        super(instance, name, true, new Short[]{CompletionType.ITEM.getShort()});
         this.addExpectedFlag(CmdItem.nameFlag);
         this.addExpectedFlag(CmdItem.loreFlag);
     }

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdRecipe.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdRecipe.java
@@ -36,6 +36,7 @@ import org.bukkit.inventory.meta.Damageable;
 import org.royaldev.royalcommands.MessageColor;
 import org.royaldev.royalcommands.RUtils;
 import org.royaldev.royalcommands.RoyalCommands;
+import org.royaldev.royalcommands.exceptions.InvalidItemNameException;
 
 
 @ReflectCommand

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdRecipe.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdRecipe.java
@@ -36,7 +36,7 @@ import org.bukkit.inventory.meta.Damageable;
 import org.royaldev.royalcommands.MessageColor;
 import org.royaldev.royalcommands.RUtils;
 import org.royaldev.royalcommands.RoyalCommands;
-import org.royaldev.royalcommands.exceptions.InvalidItemNameException;
+
 
 @ReflectCommand
 public class CmdRecipe extends TabCommand {
@@ -44,7 +44,7 @@ public class CmdRecipe extends TabCommand {
     private final Map<String, Integer> tasks = new HashMap<>();
 
     public CmdRecipe(final RoyalCommands instance, final String name) {
-        super(instance, name, true, new Short[]{CompletionType.ITEM_ALIAS.getShort()});
+        super(instance, name, true, new Short[]{CompletionType.ITEM.getShort()});
         this.plugin.getServer().getPluginManager().registerEvents(new WorkbenchCloseListener(), this.plugin);
     }
 

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdUses.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/CmdUses.java
@@ -47,7 +47,7 @@ public class CmdUses extends TabCommand {
     private final Map<String, Integer> tasks = new HashMap<>();
 
     public CmdUses(final RoyalCommands instance, final String name) {
-        super(instance, name, true, new Short[]{CompletionType.ITEM_ALIAS.getShort()});
+        super(instance, name, true, new Short[]{CompletionType.ITEM.getShort()});
         this.plugin.getServer().getPluginManager().registerEvents(new WorkbenchCloseListener(), this.plugin);
     }
 

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/TabCommand.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/TabCommand.java
@@ -112,7 +112,10 @@ public abstract class TabCommand extends CACommand implements TabCompleter {
                     final String name = m.getKeyOrNull().getKey();
                     final String lowerCaseName = name.toLowerCase();
                     if (!lowerCaseName.startsWith(arg)) continue;
+                    // Minecraft default item names
                     possibilities.add(lowerCaseName.equals(arg) ? 0 : possibilities.size(), name);
+                    // Custom item names
+                    possibilities.addAll(RoyalCommands.inm.getPossibleNames(arg));
                 }
                 break;
             case ATTRIBUTE:
@@ -279,7 +282,7 @@ public abstract class TabCommand extends CACommand implements TabCompleter {
          */
         ONLINE_PLAYER((short) 1),
         /**
-         * Completes for any item alias in items.csv.
+         * Completes for any item alias in item_aliases.csv.
          */
         ITEM_ALIAS((short) 2),
         /**

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/kits/Kit.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/kits/Kit.java
@@ -18,6 +18,7 @@ import org.royaldev.royalcommands.wrappers.player.RPlayer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 /**
  * A class representing a kit.
@@ -68,11 +69,11 @@ public class Kit {
      * @param item Node representing an ItemStack
      * @return ItemStack of null
      */
+    // TODO Handle invalid item names better
     private ItemStack getItemStack(final ConfigurationNode item) {
-        final ItemStack is = RoyalCommands.inm.getItemStackFromAlias(item.getString("type"));
-        final Damageable imd = (Damageable) is.getItemMeta();
+        final ItemStack is = RUtils.getItem(item.getString("type"), item.getInt("amount", 1));
         if (is == null) return null;
-        is.setAmount(item.getInt("amount", 1));
+        final Damageable imd = (Damageable) is.getItemMeta();
         imd.setDamage(item.getShort("damage", (short) 0));
         final ItemMeta im = is.getItemMeta();
         im.setDisplayName(RUtils.colorize(item.getString("name")));
@@ -92,7 +93,9 @@ public class Kit {
         final List<ItemStack> itemStacks = new ArrayList<>();
         for (final ConfigurationNode item : items) {
             final ItemStack is = this.getItemStack(item);
-            if (is == null) continue;
+            if (is == null) {
+                continue;
+            }
             itemStacks.add(is);
         }
         return itemStacks;

--- a/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/kits/Kit.java
+++ b/modules/RoyalCommands/src/main/java/org/royaldev/royalcommands/rcommands/kits/Kit.java
@@ -12,14 +12,11 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.royaldev.royalcommands.RUtils;
-import org.royaldev.royalcommands.RoyalCommands;
 import org.royaldev.royalcommands.shaded.com.sk89q.util.config.ConfigurationNode;
 import org.royaldev.royalcommands.wrappers.player.RPlayer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-
 /**
  * A class representing a kit.
  */

--- a/modules/RoyalCommands/src/main/resources/config.yml
+++ b/modules/RoyalCommands/src/main/resources/config.yml
@@ -279,7 +279,7 @@ kits:
       description: An example kit.
       # List of items for this kit
       items:
-        - type: LOG:OAK
+        - type: OAK_LOG
           amount: 1
           # You can use colors in lore and names
           name: "&rWood of Champions"
@@ -299,9 +299,9 @@ kits:
     wool:
       description: A kit containing wool.
       items:
-        - type: WOOL:BLACK
+        - type: BLACK_WOOL
           amount: 64
-        - type: WOOL:BLUE
+        - type: BLUE_WOOL
           amount: 35
     # This kit can only be used once (cooldown of -1)
     onetime:

--- a/modules/RoyalCommands/src/main/resources/item_aliases.csv
+++ b/modules/RoyalCommands/src/main/resources/item_aliases.csv
@@ -1,0 +1,1 @@
+#"DIAMOND_SWORD","stabby_knife"

--- a/modules/RoyalCommands/src/test/java/org/royaldev/royalcommands/TestAliases.java
+++ b/modules/RoyalCommands/src/test/java/org/royaldev/royalcommands/TestAliases.java
@@ -1,16 +1,13 @@
 package org.royaldev.royalcommands;
 
-import org.bukkit.Material;
+
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.royaldev.royalcommands.opencsv.CSVReader;
-
 import java.io.File;
-import java.io.FileReader;
-import java.io.Reader;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -18,7 +15,6 @@ import java.util.logging.Logger;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
-
 
 public class TestAliases {
 
@@ -31,25 +27,6 @@ public class TestAliases {
             this.pluginYml = YamlConfiguration.loadConfiguration(pluginFile);
         }
         return this.pluginYml;
-    }
-
-    @Test
-    public void testAliases() throws Throwable {
-        final Logger l = Logger.getLogger("org.royaldev.royalcommands");
-        final File csv = new File("src/main/resources/items.csv");
-        assertTrue("No items.csv found!", csv.exists());
-        final Reader in = new FileReader(csv);
-        CSVReader r = new CSVReader(in);
-        final ItemNameManager inm = new ItemNameManager(r.readAll());
-        boolean allAliasesExist = true;
-        for (final Material m : Material.values()) {
-            if (inm.aliasExists(m)) continue;
-            if (m.name().startsWith("LEGACY")) continue;
-            if (allAliasesExist) allAliasesExist = false;
-            l.warning("Missing alias for Material " + m.name() + ".");
-        }
-        r.close();
-        assertTrue("Missing aliases!", allAliasesExist);
     }
 
     private RoyalCommands makeRoyalCommands() {


### PR DESCRIPTION
Made item aliases an optional feature, item aliases can now be set in item_aliases.csv when required. Also makes the default kit valid  now (excluding an issue with damage values).